### PR TITLE
Add PostgreSQL login backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ EHR-ENG2 provides a simple starting point for building an EHR interface with the
 - `node_modules/` – installed dependencies. Changes to this folder should not be committed.
 - `.git/` – version control files managed by Git.
 - `src/components/LoginLanding.vue` – example login landing page component.
+- `server/index.js` – minimal Express server connecting to PostgreSQL.
 
 ## Getting Started
 
@@ -29,6 +30,17 @@ EHR-ENG2 provides a simple starting point for building an EHR interface with the
    ```bash
    npm run build
    ```
+
+## Backend Server
+
+The server in `server/index.js` connects to a PostgreSQL database using the `pg` library. Set the `DATABASE_URL` environment variable and run:
+
+```bash
+  npm install
+  npm run dev:server
+```
+
+The `/api/login` endpoint accepts `email` and `password` fields for authentication.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ehr-eng2",
+  "version": "1.0.0",
+  "scripts": {
+    "dev:server": "node server/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.10.0"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,33 @@
+const express = require('express')
+const { Pool } = require('pg')
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL
+})
+
+const app = express()
+const PORT = process.env.PORT || 3000
+
+app.use(express.json())
+
+app.post('/api/login', async (req, res) => {
+  const { email, password } = req.body
+  try {
+    const result = await pool.query(
+      'SELECT id FROM users WHERE email = $1 AND password = $2',
+      [email, password]
+    )
+    if (result.rows.length > 0) {
+      res.json({ success: true })
+    } else {
+      res.status(401).json({ success: false, message: 'Invalid credentials' })
+    }
+  } catch (error) {
+    console.error('Login error:', error)
+    res.status(500).json({ success: false })
+  }
+})
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`)
+})

--- a/src/components/LoginLanding.vue
+++ b/src/components/LoginLanding.vue
@@ -43,9 +43,21 @@ const emit = defineEmits(['login'])
 const email = ref('')
 const password = ref('')
 
-function handleSubmit() {
+async function handleSubmit() {
   const payload = { email: email.value, password: password.value }
-  emit('login', payload)
+  try {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    if (!res.ok) {
+      throw new Error('Login failed')
+    }
+    emit('login', payload)
+  } catch (error) {
+    console.error(error)
+  }
 }
 </script>
 


### PR DESCRIPTION
## Summary
- add minimal Express server with `/api/login` endpoint backed by PostgreSQL
- update login component to POST credentials to new endpoint
- document backend server and setup steps
- include package.json for server dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e08d25c748326bca7aee78aef77a2