### PR TITLE
Configure Vite dev proxy

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,11 @@ export default defineConfig({
   plugins: [vue()],
   server: {
     proxy: {
-      '/api': 'http://localhost:3000'
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true
+      }
     }
   }
 })
+


### PR DESCRIPTION
## Summary
- route `/api` requests to backend via Vite proxy

## Testing
- `npm run lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_684f30a0575483268993e7c89c46c49b