### PR TITLE
Fix API paths and add proxy test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ npm run test
 npm run test:e2e
 ```
 
+### API Test Scripts
+
+Use the provided scripts to verify API endpoints during development:
+
+```bash
+# Test login endpoint
+npm run test:login
+
+# Test patient list endpoint
+npm run test:patients
+```
+
 ## 📝 API Documentation
 
 ### Authentication Endpoints

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "preview": "node node_modules/vite/bin/vite.js preview",
     "start:server": "node server/index.js",
     "stop:server": "npx kill-port 3000",
-    "test:login": "node scripts/test-login.js"
+    "test:login": "node scripts/test-login.js",
+    "test:patients": "node scripts/test-patients.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",

--- a/scripts/test-patients.js
+++ b/scripts/test-patients.js
@@ -1,0 +1,20 @@
+try {
+  require('dotenv').config()
+} catch {
+  console.warn('dotenv not installed; skipping .env loading')
+}
+
+const url = process.env.PATIENTS_URL || 'http://localhost:3000/api/patients'
+
+async function run() {
+  const res = await fetch(url)
+  console.log('Status:', res.status)
+  const data = await res.json()
+  console.log('Patients:', data)
+}
+
+run().catch(err => {
+  console.error('Patient request failed:', err)
+  process.exit(1)
+})
+

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -53,7 +53,7 @@ export default {
   methods: {
     async handleLogin() {
       try {
-        const response = await fetch('http://localhost:3000/api/login', {
+        const response = await fetch('/api/login', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/src/components/PatientManagement.vue
+++ b/src/components/PatientManagement.vue
@@ -222,7 +222,7 @@ export default {
     },
     async fetchPatients() {
       try {
-        const response = await fetch('http://localhost:3000/api/patients')
+        const response = await fetch('/api/patients')
         const data = await response.json()
         this.patients = data
       } catch (error) {
@@ -234,7 +234,7 @@ export default {
       this.searchTimeout = setTimeout(async () => {
         if (this.searchQuery.trim()) {
           try {
-            const response = await fetch(`http://localhost:3000/api/patients/search/${this.searchQuery}`)
+            const response = await fetch(`/api/patients/search/${this.searchQuery}`)
             const data = await response.json()
             this.patients = data
           } catch (error) {
@@ -262,8 +262,8 @@ export default {
     async savePatient() {
       try {
         const url = this.editingPatient
-          ? `http://localhost:3000/api/patients/${this.editingPatient.id}`
-          : 'http://localhost:3000/api/patients'
+          ? `/api/patients/${this.editingPatient.id}`
+          : '/api/patients'
         
         const response = await fetch(url, {
           method: this.editingPatient ? 'PUT' : 'POST',
@@ -289,7 +289,7 @@ export default {
     },
     async deletePatientRecord() {
       try {
-        const response = await fetch(`http://localhost:3000/api/patients/${this.deletePatient.id}`, {
+        const response = await fetch(`/api/patients/${this.deletePatient.id}`, {
           method: 'DELETE'
         })
 


### PR DESCRIPTION
## Summary
- switch Login and PatientManagement components to use proxy URLs
- add `scripts/test-patients.js` to verify patient endpoint
- document test scripts in README
- expose `npm run test:patients` script

## Testing
- `npm install`
- `npm run build`
- `npm run dev` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_684f3262a87483269924bb4f057c7f43