### PR TITLE
Fix App.vue template syntax error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Environment configuration
+DATABASE_URL=postgres://user:password@localhost:5432/ehr-eng2
+TEST_EMAIL=admin@example.com
+TEST_PASSWORD=secret
+SERVER_URL=http://localhost:3000/api/login

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -15,9 +15,10 @@
    ```
 
 2. **Environment Variables**
-   - **Challenge**: Secure credential management
-   - **Solution**: Implemented .env file with DATABASE_URL
-   - **Learning**: Never commit sensitive credentials, use environment variables
+  - **Challenge**: Secure credential management
+  - **Solution**: Implemented .env file with DATABASE_URL
+  - **Learning**: Never commit sensitive credentials, use environment variables
+  - **Tip**: Copy `.env.example` to `.env` and update credentials locally
 
 ## 🌐 CORS & API Security
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@
 # Install dependencies
 npm install
 
+# Copy environment configuration
+cp .env.example .env
+# Update DATABASE_URL with your Postgres credentials
+
 # Start the backend server
-$env:DATABASE_URL="postgres://web:password123@localhost:5432/ehr-eng2"; node server/index.js
+node server/index.js
 
 # Start the frontend development server
 npm run dev

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,4 @@
 <template>
-
   <div>
     <header class="p-4">
       <button
@@ -10,12 +9,13 @@
       </button>
     </header>
 
-  <div class="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-    <div class="p-4 text-right">
-      <ThemeSwitcher />
-    </div>
+    <div class="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <div class="p-4 text-right">
+        <ThemeSwitcher />
+      </div>
 
-    <router-view></router-view>
+      <router-view></router-view>
+    </div>
   </div>
 </template>
 
@@ -27,14 +27,15 @@ const router = useRouter()
 
 function goBack() {
   router.back()
-=======
+}
+</script>
+
 <script>
 import ThemeSwitcher from './components/ThemeSwitcher.vue'
 
 export default {
   name: 'App',
   components: { ThemeSwitcher }
-
 }
 </script>
 


### PR DESCRIPTION
## Summary
- close div tag and remove conflict markers in App.vue
- add `.env.example` for local setup
- document environment configuration steps
- note `.env` copy tip in lessons

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-vue')*

------
https://chatgpt.com/codex/tasks/task_e_684f44ebf19c832695ee4d8055dce6a4