### PR TITLE
Fix dark mode contrast for dashboard header

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ npm run test:patients
 - CSS uses Tailwind utility classes
 - Follows ESLint configuration
 - Phone numbers are stored as digits and formatted to `(XXX)-XXX-XXXX` in the UI
+- Dashboard header text uses `dark:text-gray-200` for better readability
 
 ### Branch Strategy
 - main: Production-ready code

--- a/src/components/PatientDashboard.vue
+++ b/src/components/PatientDashboard.vue
@@ -14,12 +14,12 @@
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50 dark:bg-gray-600">
           <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Gender</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">DOB</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Phone</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Insurance</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">Name</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">Gender</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">DOB</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">Phone</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">Insurance</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">Actions</th>
           </tr>
         </thead>
         <tbody class="bg-white dark:bg-gray-700 divide-y divide-gray-200 dark:divide-gray-600">


### PR DESCRIPTION
## Summary
- adjust table header colors in `PatientDashboard.vue`
- document dark mode improvement in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f50097fac8326abb76ae10ee1f9b9