### PR TITLE
Fix input field text color in patient form

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ npm run test:patients
 - Follows ESLint configuration
 - Phone numbers are stored as digits and formatted to `(XXX)-XXX-XXXX` in the UI
 - Dashboard header text uses `dark:text-gray-200` for better readability
+- Input fields in the Add Patient form now use `text-gray-800` and
+  `dark:text-gray-100` to improve readability
 
 ### Branch Strategy
 - main: Production-ready code

--- a/src/components/PatientManagement.vue
+++ b/src/components/PatientManagement.vue
@@ -8,7 +8,7 @@
           v-model="searchQuery"
           @input="handleSearch"
           placeholder="Search patients..."
-          class="w-full px-4 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          class="w-full px-4 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
         />
       </div>
       <button
@@ -85,7 +85,7 @@
                 type="text"
                 v-model="patientForm.first_name"
                 required
-                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
               />
             </div>
             <div class="mb-4">
@@ -94,7 +94,7 @@
                 type="text"
                 v-model="patientForm.last_name"
                 required
-                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
               />
             </div>
             <div class="mb-4">
@@ -102,7 +102,7 @@
               <select
                 v-model="patientForm.gender"
                 required
-                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
               >
                 <option value="Male">Male</option>
                 <option value="Female">Female</option>
@@ -114,7 +114,7 @@
               <select
                 v-model="patientForm.marital_status"
                 required
-                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
               >
                 <option value="Single">Single</option>
                 <option value="Married">Married</option>
@@ -127,7 +127,7 @@
               <select
                 v-model="patientForm.blood_type"
                 required
-                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
               >
                 <option value="A+">A+</option>
                 <option value="A-">A-</option>
@@ -145,7 +145,7 @@
                 type="date"
                 v-model="patientForm.date_of_birth"
                 required
-                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
               />
             </div>
             <div class="mb-4">
@@ -154,7 +154,7 @@
                 type="tel"
                 v-model="formattedPhoneNumber"
                 required
-                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
               />
             </div>
             <div class="mb-4">
@@ -163,7 +163,7 @@
                 type="text"
                 v-model="patientForm.insurance_provider"
                 required
-                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
               />
             </div>
             <div class="mb-4">
@@ -172,7 +172,7 @@
                 type="text"
                 v-model="patientForm.insurance_id"
                 required
-                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-800 dark:text-gray-100"
               />
             </div>
             <div class="flex justify-end mt-6">


### PR DESCRIPTION
## Summary
- darken text color of search field and Add Patient form inputs
- document updated form styling in README

## Testing
- `npm run lint`
- `npm run test:login` *(fails: fetch failed)*
- `npm run test:patients` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68502f963f8883269dbe148efa00fd4d