### PR TITLE
Fix dark mode input text visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ npm run test:patients
 - Phone numbers are stored as digits and formatted to `(XXX)-XXX-XXXX` in the UI
 - Dashboard header text uses `dark:text-gray-200` for better readability
 - Input fields in the Add Patient form now use `text-gray-800` and
-   `dark:text-gray-200` to improve readability
+  `dark:text-gray-100` to improve readability
 
 ### Branch Strategy
 - main: Production-ready code

--- a/src/components/AddPatientForm.vue
+++ b/src/components/AddPatientForm.vue
@@ -2,15 +2,15 @@
   <form @submit.prevent="handleSubmit" class="grid grid-cols-2 gap-4">
     <div>
       <label class="block text-sm font-bold mb-1">First Name</label>
-      <input type="text" v-model="form.first_name" required class="w-full px-3 py-2 border rounded" />
+      <input type="text" v-model="form.first_name" required class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100" />
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Last Name</label>
-      <input type="text" v-model="form.last_name" required class="w-full px-3 py-2 border rounded" />
+      <input type="text" v-model="form.last_name" required class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100" />
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Gender</label>
-      <select v-model="form.gender" class="w-full px-3 py-2 border rounded">
+      <select v-model="form.gender" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100">
         <option value="">Select</option>
         <option value="Male">Male</option>
         <option value="Female">Female</option>
@@ -19,7 +19,7 @@
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Marital Status</label>
-      <select v-model="form.marital_status" class="w-full px-3 py-2 border rounded">
+      <select v-model="form.marital_status" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100">
         <option value="">Select</option>
         <option value="Single">Single</option>
         <option value="Married">Married</option>
@@ -29,7 +29,7 @@
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Blood Type</label>
-      <select v-model="form.blood_type" class="w-full px-3 py-2 border rounded">
+      <select v-model="form.blood_type" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100">
         <option value="A+">A+</option>
         <option value="A-">A-</option>
         <option value="B+">B+</option>
@@ -42,7 +42,7 @@
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">RH Factor</label>
-      <select v-model="form.rh_factor" class="w-full px-3 py-2 border rounded">
+      <select v-model="form.rh_factor" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100">
         <option value="">Select</option>
         <option value="Positive">Positive</option>
         <option value="Negative">Negative</option>
@@ -50,7 +50,7 @@
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Duty Status</label>
-      <select v-model="form.duty_status" class="w-full px-3 py-2 border rounded">
+      <select v-model="form.duty_status" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100">
         <option value="">Select</option>
         <option value="Active">Active</option>
         <option value="Reserve">Reserve</option>
@@ -59,7 +59,7 @@
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Paygrade</label>
-      <select v-model="form.paygrade" class="w-full px-3 py-2 border rounded">
+      <select v-model="form.paygrade" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100">
         <option value="E1">E1</option>
         <option value="E2">E2</option>
         <option value="E3">E3</option>
@@ -69,7 +69,7 @@
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Branch of Service</label>
-      <select v-model="form.branch_of_service" class="w-full px-3 py-2 border rounded">
+      <select v-model="form.branch_of_service" data-test="branch-select" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100">
         <option value="">Select</option>
         <option value="Army">Army</option>
         <option value="Navy">Navy</option>
@@ -82,27 +82,27 @@
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">PID</label>
-      <input type="text" v-model="form.pid" class="w-full px-3 py-2 border rounded" />
+      <input type="text" v-model="form.pid" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100" />
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">DoD ID</label>
-      <input type="number" v-model.number="form.dod_id" class="w-full px-3 py-2 border rounded" />
+      <input type="number" v-model.number="form.dod_id" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100" />
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Ethnicity</label>
-      <input type="text" v-model="form.ethnicity" class="w-full px-3 py-2 border rounded" />
+      <input type="text" v-model="form.ethnicity" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100" />
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Religion</label>
-      <input type="text" v-model="form.religion" class="w-full px-3 py-2 border rounded" />
+      <input type="text" v-model="form.religion" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100" />
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Date of Birth</label>
-      <input type="date" v-model="form.date_of_birth" required class="w-full px-3 py-2 border rounded" />
+      <input type="date" v-model="form.date_of_birth" required class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100" />
     </div>
     <div>
       <label class="block text-sm font-bold mb-1">Phone Number</label>
-      <input type="tel" v-model="form.phone_number" class="w-full px-3 py-2 border rounded" />
+      <input type="tel" v-model="form.phone_number" class="w-full px-3 py-2 border rounded text-gray-800 dark:text-gray-100" />
     </div>
     <div class="col-span-2 flex justify-end mt-4">
       <button type="button" @click="$emit('cancel')" class="px-4 py-2 bg-gray-200 rounded mr-2">Cancel</button>


### PR DESCRIPTION
## Summary
- improve text color for all inputs in AddPatientForm.vue to ensure readability in dark mode
- note the new dark text class in README

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-vue')*

------
https://chatgpt.com/codex/tasks/task_e_68541fdf15148326b30c6f235f671af6