### PR TITLE
Add Environmental Exposure Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,24 @@ After successful login, users can access two main modules:
    - Blue-themed interface
 
 2. **RH Module (Resource & Hospital)**
-   - Access via `/rh-module` route
-   - Manages hospital resources
-   - Features (Coming Soon):
-     - Staff Management
-     - Equipment Tracking
-     - Facility Management
-   - Green-themed interface
+ - Access via `/rh-module` route
+  - Manages hospital resources
+  - Features (Coming Soon):
+    - Staff Management
+    - Equipment Tracking
+    - Facility Management
+  - Green-themed interface
 
-3. **Settings**
+3. **Exposure Dashboard**
+  - Access via `/exposure` route
+  - Tracks environmental hazards and sample testing
+  - Purple-themed interface
+4. **Settings**
   - Access via `/settings` route
   - Visible only to admin users
   - Allows admins to change any user's password
 
-4. **System Status**
+5. **System Status**
   - Access via `/status` route
   - Displays API and database availability
   - Real-time service health monitoring

--- a/src/components/ModuleSelection.vue
+++ b/src/components/ModuleSelection.vue
@@ -2,7 +2,7 @@
   <div class="min-h-screen bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
     <div class="max-w-2xl w-full mx-4">
       <h1 class="text-3xl font-bold text-center mb-8 text-gray-800 dark:text-gray-100">Select Module</h1>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
         <!-- EH Module Card -->
         <div
           @click="goToModule('EH')"
@@ -30,6 +30,20 @@
             </button>
           </div>
         </div>
+
+        <!-- Exposure Dashboard Card -->
+        <div
+          @click="goToModule('EX')"
+          class="bg-white dark:bg-gray-700 rounded-lg shadow-lg p-6 cursor-pointer transform transition-transform hover:scale-105"
+        >
+          <h2 class="text-2xl font-semibold text-purple-600 mb-3">Exposure Dashboard</h2>
+          <p class="text-gray-600 dark:text-gray-300">Environmental Exposure Tracking</p>
+          <div class="mt-4 flex justify-end">
+            <button class="bg-purple-500 text-white px-4 py-2 rounded hover:bg-purple-600 transition-colors">
+              Select Exposure
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -40,7 +54,10 @@ export default {
   name: 'ModuleSelection',
   methods: {
     goToModule(module) {
-      const path = module === 'EH' ? '/eh-module' : '/rh-module'
+      let path = ''
+      if (module === 'EH') path = '/eh-module'
+      else if (module === 'RH') path = '/rh-module'
+      else path = '/exposure'
       this.$router.push(path)
     }
   }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,7 @@ import PatientManagement from '../components/PatientManagement.vue'
 import Settings from '../components/Settings.vue'
 import SystemStatus from '../views/SystemStatus.vue'
 import PatientView from '../views/PatientView.vue'
+import ExposureDashboard from '../views/ExposureDashboard.vue'
 
 const routes = [
   {
@@ -42,6 +43,12 @@ const routes = [
     path: '/patients/view/:id',
     name: 'PatientView',
     component: PatientView,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/exposure',
+    name: 'ExposureDashboard',
+    component: ExposureDashboard,
     meta: { requiresAuth: true }
   },
   {

--- a/src/views/ExposureDashboard.vue
+++ b/src/views/ExposureDashboard.vue
@@ -1,0 +1,174 @@
+<template>
+  <div class="min-h-screen bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-4">
+    <h1 class="text-3xl font-bold mb-6">Environmental Exposure Dashboard</h1>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+      <div class="bg-white dark:bg-gray-700 p-4 rounded shadow">
+        <p class="text-sm text-gray-500 dark:text-gray-300">Total Monitored Locations</p>
+        <p class="text-2xl font-semibold">{{ metrics.locations }}</p>
+      </div>
+      <div class="bg-white dark:bg-gray-700 p-4 rounded shadow">
+        <p class="text-sm text-gray-500 dark:text-gray-300">Personnel at Risk</p>
+        <p class="text-2xl font-semibold">{{ metrics.personnel }}</p>
+      </div>
+      <div class="bg-white dark:bg-gray-700 p-4 rounded shadow">
+        <p class="text-sm text-gray-500 dark:text-gray-300">Open Exposure Incidents</p>
+        <p class="text-2xl font-semibold">{{ metrics.incidents }}</p>
+      </div>
+      <div class="bg-white dark:bg-gray-700 p-4 rounded shadow">
+        <p class="text-sm text-gray-500 dark:text-gray-300">Samples Awaiting Lab Results</p>
+        <p class="text-2xl font-semibold">{{ metrics.samples }}</p>
+      </div>
+    </div>
+
+    <div class="space-y-8">
+      <!-- Location-Based Exposure -->
+      <section class="bg-white dark:bg-gray-700 p-4 rounded shadow">
+        <h2 class="text-xl font-semibold mb-4">Location-Based Exposure</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+          <div>
+            <label class="block text-sm mb-1">Unit/Base Name</label>
+            <select class="w-full p-2 border rounded bg-gray-50 dark:bg-gray-800">
+              <option>Main Base</option>
+              <option>Forward Site</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm mb-1">Hazard Type</label>
+            <select class="w-full p-2 border rounded bg-gray-50 dark:bg-gray-800">
+              <option>Asbestos</option>
+              <option>Jet Fuel</option>
+              <option>Lead</option>
+            </select>
+          </div>
+        </div>
+        <table class="w-full text-left text-sm">
+          <thead>
+            <tr>
+              <th class="px-2 py-1">Location</th>
+              <th class="px-2 py-1">Sample</th>
+              <th class="px-2 py-1">Value</th>
+              <th class="px-2 py-1">Threshold</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in locationSamples" :key="item.id" class="border-t">
+              <td class="px-2 py-1">{{ item.location }}</td>
+              <td class="px-2 py-1">{{ item.sampleType }}</td>
+              <td class="px-2 py-1">{{ item.value }}</td>
+              <td class="px-2 py-1">{{ item.threshold }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Individual Exposure History -->
+      <section class="bg-white dark:bg-gray-700 p-4 rounded shadow">
+        <h2 class="text-xl font-semibold mb-4">Individual Exposure History</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+          <div>
+            <label class="block text-sm mb-1">Service Member</label>
+            <input type="text" class="w-full p-2 border rounded bg-gray-50 dark:bg-gray-800" placeholder="Name or DoD ID" />
+          </div>
+        </div>
+        <table class="w-full text-left text-sm">
+          <thead>
+            <tr>
+              <th class="px-2 py-1">Deployment</th>
+              <th class="px-2 py-1">Symptoms</th>
+              <th class="px-2 py-1">Cumulative Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in exposureHistory" :key="item.id" class="border-t">
+              <td class="px-2 py-1">{{ item.deployment }}</td>
+              <td class="px-2 py-1">{{ item.symptoms }}</td>
+              <td class="px-2 py-1">{{ item.score }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Material Safety Tracking -->
+      <section class="bg-white dark:bg-gray-700 p-4 rounded shadow">
+        <h2 class="text-xl font-semibold mb-4">Material Safety Tracking</h2>
+        <table class="w-full text-left text-sm">
+          <thead>
+            <tr>
+              <th class="px-2 py-1">Material</th>
+              <th class="px-2 py-1">Location</th>
+              <th class="px-2 py-1">Amount</th>
+              <th class="px-2 py-1">Last Inspection</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in materials" :key="item.id" class="border-t">
+              <td class="px-2 py-1">{{ item.name }}</td>
+              <td class="px-2 py-1">{{ item.location }}</td>
+              <td class="px-2 py-1">{{ item.amount }}</td>
+              <td class="px-2 py-1">{{ item.inspection }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Sample Testing Logs -->
+      <section class="bg-white dark:bg-gray-700 p-4 rounded shadow">
+        <h2 class="text-xl font-semibold mb-4">Sample Testing Logs</h2>
+        <table class="w-full text-left text-sm">
+          <thead>
+            <tr>
+              <th class="px-2 py-1">Sample ID</th>
+              <th class="px-2 py-1">Date</th>
+              <th class="px-2 py-1">Type</th>
+              <th class="px-2 py-1">Location</th>
+              <th class="px-2 py-1">Result</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in sampleLogs" :key="item.id" class="border-t">
+              <td class="px-2 py-1">{{ item.id }}</td>
+              <td class="px-2 py-1">{{ item.date }}</td>
+              <td class="px-2 py-1">{{ item.type }}</td>
+              <td class="px-2 py-1">{{ item.location }}</td>
+              <td class="px-2 py-1">{{ item.result }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ExposureDashboard',
+  data() {
+    return {
+      metrics: {
+        locations: 3,
+        personnel: 12,
+        incidents: 2,
+        samples: 5
+      },
+      locationSamples: [
+        { id: 1, location: 'Main Base', sampleType: 'Air', value: '0.5 ppm', threshold: '1 ppm' },
+        { id: 2, location: 'Forward Site', sampleType: 'Water', value: '3 ppb', threshold: '5 ppb' }
+      ],
+      exposureHistory: [
+        { id: 1, deployment: '2021-2022', symptoms: 'None', score: 10 },
+        { id: 2, deployment: '2020', symptoms: 'Coughing', score: 20 }
+      ],
+      materials: [
+        { id: 1, name: 'JP-8', location: 'Hangar', amount: '200 L', inspection: '2024-04-01' },
+        { id: 2, name: 'Asbestos', location: 'Storage A', amount: '50 kg', inspection: '2024-03-15' }
+      ],
+      sampleLogs: [
+        { id: 'S-001', date: '2024-04-01', type: 'Air', location: 'Main Base', result: '0.5 ppm' },
+        { id: 'S-002', date: '2024-04-05', type: 'Soil', location: 'Forward Site', result: '2 ppm' }
+      ]
+    }
+  }
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- add Exposure Dashboard Vue view with mock data
- register new route for exposure dashboard
- link exposure dashboard from module selection
- document new module in README

## Testing
- `npm run lint` *(fails: eslint-plugin-vue missing)*

------
https://chatgpt.com/codex/tasks/task_e_68544831dfdc83268fce41dab0a2f44d