### PR TITLE
Fix AddPatientForm dark mode visibility

### DIFF
--- a/src/components/AddPatientForm.vue
+++ b/src/components/AddPatientForm.vue
@@ -1,16 +1,16 @@
 <template>
   <form @submit.prevent="handleSubmit" class="grid grid-cols-2 gap-4">
     <div>
-      <label class="block text-sm font-bold mb-1">First Name</label>
-      <input type="text" v-model="form.first_name" required class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100" />
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">First Name</label>
+      <input type="text" v-model="form.first_name" required class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800" />
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Last Name</label>
-      <input type="text" v-model="form.last_name" required class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100" />
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Last Name</label>
+      <input type="text" v-model="form.last_name" required class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800" />
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Gender</label>
-      <select v-model="form.gender" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100">
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Gender</label>
+      <select v-model="form.gender" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800">
         <option value="">Select</option>
         <option value="Male">Male</option>
         <option value="Female">Female</option>
@@ -18,8 +18,8 @@
       </select>
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Marital Status</label>
-      <select v-model="form.marital_status" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100">
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Marital Status</label>
+      <select v-model="form.marital_status" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800">
         <option value="">Select</option>
         <option value="Single">Single</option>
         <option value="Married">Married</option>
@@ -28,8 +28,8 @@
       </select>
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Blood Type</label>
-      <select v-model="form.blood_type" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100">
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Blood Type</label>
+      <select v-model="form.blood_type" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800">
         <option value="A+">A+</option>
         <option value="A-">A-</option>
         <option value="B+">B+</option>
@@ -41,16 +41,16 @@
       </select>
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">RH Factor</label>
-      <select v-model="form.rh_factor" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100">
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">RH Factor</label>
+      <select v-model="form.rh_factor" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800">
         <option value="">Select</option>
         <option value="Positive">Positive</option>
         <option value="Negative">Negative</option>
       </select>
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Duty Status</label>
-      <select v-model="form.duty_status" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100">
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Duty Status</label>
+      <select v-model="form.duty_status" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800">
         <option value="">Select</option>
         <option value="Active">Active</option>
         <option value="Reserve">Reserve</option>
@@ -58,8 +58,8 @@
       </select>
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Paygrade</label>
-      <select v-model="form.paygrade" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100">
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Paygrade</label>
+      <select v-model="form.paygrade" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800">
         <option value="E1">E1</option>
         <option value="E2">E2</option>
         <option value="E3">E3</option>
@@ -68,8 +68,8 @@
       </select>
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Branch of Service</label>
-      <select v-model="form.branch_of_service" data-test="branch-select" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100">
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Branch of Service</label>
+      <select v-model="form.branch_of_service" data-test="branch-select" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800">
         <option value="">Select</option>
         <option value="Army">Army</option>
         <option value="Navy">Navy</option>
@@ -81,28 +81,28 @@
       </select>
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">PID</label>
-      <input type="text" v-model="form.pid" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100" />
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">PID</label>
+      <input type="text" v-model="form.pid" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800" />
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">DoD ID</label>
-      <input type="number" v-model.number="form.dod_id" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100" />
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">DoD ID</label>
+      <input type="number" v-model.number="form.dod_id" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800" />
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Ethnicity</label>
-      <input type="text" v-model="form.ethnicity" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100" />
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Ethnicity</label>
+      <input type="text" v-model="form.ethnicity" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800" />
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Religion</label>
-      <input type="text" v-model="form.religion" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100" />
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Religion</label>
+      <input type="text" v-model="form.religion" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800" />
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Date of Birth</label>
-      <input type="date" v-model="form.date_of_birth" required class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100" />
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Date of Birth</label>
+      <input type="date" v-model="form.date_of_birth" required class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800" />
     </div>
     <div>
-      <label class="block text-sm font-bold mb-1">Phone Number</label>
-      <input type="tel" v-model="form.phone_number" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100" />
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Phone Number</label>
+      <input type="tel" v-model="form.phone_number" class="w-full px-3 py-2 border rounded text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800" />
     </div>
     <div class="col-span-2 flex justify-end mt-4">
       <button type="button" @click="$emit('cancel')" class="px-4 py-2 bg-gray-200 rounded mr-2">Cancel</button>


### PR DESCRIPTION
## Summary
- fix text and background colors for AddPatientForm inputs in dark mode

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685448d8c0c48326a54a174311a08a0c