### PR TITLE
Add last login tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ npm run test:patients
 
 #### POST /api/login
 - Request body: `{ email: string, password: string }`
-- Response: `{ success: boolean, role?: string, userId?: number, message?: string }`
+- Response: `{ success: boolean, role?: string, userId?: number, lastLoginAt?: string, message?: string }`
 
 ### Patient Management Endpoints
 
@@ -225,7 +225,7 @@ npm run test:patients
 
 #### GET /api/admin/users
   - Query parameters: `adminEmail`, `adminPassword`
-  - Response: Array of `{ id, email }`
+  - Response: Array of `{ id, email, last_login_at }`
 
 #### PUT /api/admin/users/:id/password
   - Request body: `{ adminEmail: string, adminPassword: string, newPassword: string }`

--- a/db/migrations/004_add_last_login_at.sql
+++ b/db/migrations/004_add_last_login_at.sql
@@ -1,0 +1,3 @@
+-- Add last_login_at column to users table
+ALTER TABLE IF EXISTS users
+  ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMPTZ;

--- a/server/index.js
+++ b/server/index.js
@@ -79,7 +79,11 @@ app.post('/api/login', async (req, res) => {
         )
         console.log('Updated password hash for user')
       }
-      res.json({ success: true, role: user.role, userId: user.id })
+      const updated = await pool.query(
+        'UPDATE users SET last_login_at = NOW() WHERE id = $1 RETURNING last_login_at',
+        [user.id]
+      )
+      res.json({ success: true, role: user.role, userId: user.id, lastLoginAt: updated.rows[0].last_login_at })
     } else {
       res.status(401).json({ success: false, message: 'Invalid credentials' })
     }
@@ -161,7 +165,7 @@ app.get('/api/admin/users', async (req, res) => {
       return res.status(403).json({ error: 'Unauthorized' })
     }
 
-  const users = await pool.query('SELECT id, email FROM users ORDER BY email')
+  const users = await pool.query('SELECT id, email, last_login_at FROM users ORDER BY email')
   res.json(users.rows)
   } catch (err) {
     console.error('User list error:', err)

--- a/src/components/EHModule.vue
+++ b/src/components/EHModule.vue
@@ -30,6 +30,10 @@
             </div>
           </div>
           <div class="flex items-center">
+            <div class="hidden sm:flex flex-col items-end mr-4">
+              <span class="font-medium">{{ userEmail }}</span>
+              <span v-if="lastLogin" class="text-xs text-gray-500 dark:text-gray-400">Last login: {{ lastLogin }}</span>
+            </div>
             <button
               @click="logout"
               class="ml-4 px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
@@ -94,6 +98,15 @@ export default {
   computed: {
     isAdmin() {
       return localStorage.getItem('userRole') === 'admin'
+    },
+    userEmail() {
+      return localStorage.getItem('userEmail') || ''
+    },
+    lastLogin() {
+      const ts = localStorage.getItem('lastLoginAt')
+      if (!ts) return ''
+      const date = new Date(ts)
+      return date.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })
     }
   },
   methods: {
@@ -101,6 +114,7 @@ export default {
       localStorage.removeItem('isAuthenticated')
       localStorage.removeItem('userRole')
       localStorage.removeItem('userEmail')
+      localStorage.removeItem('lastLoginAt')
       localStorage.removeItem('adminPassword')
       this.$router.push('/')
     },

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -71,6 +71,9 @@ export default {
           localStorage.setItem('isAuthenticated', 'true')
           localStorage.setItem('userRole', data.role)
           localStorage.setItem('userEmail', this.email)
+          if (data.lastLoginAt) {
+            localStorage.setItem('lastLoginAt', data.lastLoginAt)
+          }
           if (data.role === 'admin') {
             localStorage.setItem('adminPassword', this.password)
           }


### PR DESCRIPTION
## Summary
- add migration for `last_login_at` column in users table
- update backend login logic to record timestamp and return it
- expose `last_login_at` in admin user listing
- show last login time in EH module header
- persist last login time in browser storage
- document API changes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:patients` *(fails: fetch failed)*


------
https://chatgpt.com/codex/tasks/task_e_6859635e3d40832697a6c90100ea1e14