### PR TITLE
Fix ModuleSelection template syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,4 @@ If the last login timestamp is not displaying:
 - Backend and manual SQL client must connect to the same database instance.
 - Schema changes must be applied to the correct database.
 - The backend uses camelCase (`lastLoginAt`) in JSON, but the database uses snake_case (`last_login_at`).
+- Improperly closed HTML tags can cause Vite build errors like `[vue/compiler-sfc] Unexpected token`. Ensure component templates are well-formed.

--- a/src/components/ModuleSelection.vue
+++ b/src/components/ModuleSelection.vue
@@ -8,8 +8,7 @@
           <span
             v-if="lastLogin"
             class="block text-xs text-gray-600 dark:text-gray-300 mt-1"
-            >Last login: {{ lastLogin }}</span
-          >
+          >Last login: {{ lastLogin }}</span>
         </div>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -61,12 +60,11 @@ export default {
     }
   },
   methods: {
-      goToModule(module) {
-        let path = ""
-        if (module === "EH") path = "/eh-module"
-        else if (module === "RH") path = "/rh-module"
-        this.$router.push(path)
-      }
+    goToModule(module) {
+      let path = ""
+      if (module === "EH") path = "/eh-module"
+      else if (module === "RH") path = "/rh-module"
+      this.$router.push(path)
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix closing span tag in `ModuleSelection.vue`
- remove extra closing brace
- document Vite build error troubleshooting

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-vue')*

------
https://chatgpt.com/codex/tasks/task_e_685bf69dbd408326be9572560b5a0b43