### PR TITLE
Add environment status card

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ After successful login, users can access two main modules:
      - Medical Records
      - Appointment Scheduling
      - Environmental Dashboard for exposure tracking
+     - Environment status cards with modal details
    - Blue-themed interface
 
 2. **RH Module (Resource & Hospital)**
@@ -94,6 +95,7 @@ ehr-eng2/
 │   └── patients table with duty status, PID, paygrade, branch_of_service, ethnicity, religion, RH factor and DoD ID fields
 ├── src/                # Frontend source code
 │   ├── components/     # Vue components (includes EHModulesScreen and EnvironmentalDashboard)
+│                       # plus EnvironmentStatusCard
 │   ├── composables/    # Reusable logic
 │   ├── router/         # Vue router configuration
 │   ├── assets/         # Static assets like images and fonts

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,18 +1,18 @@
 -- Create users table
 CREATE TABLE IF NOT EXISTS users (
-    id SERIAL PRIMARY KEY,
-    email VARCHAR(255) UNIQUE NOT NULL,
-    password_hash VARCHAR(255) NOT NULL,
-    role VARCHAR(50) NOT NULL DEFAULT 'user',
-    last_login_at TIMESTAMPTZ
+  id SERIAL PRIMARY KEY,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  role VARCHAR(50) NOT NULL DEFAULT 'user',
+  last_login_at TIMESTAMPTZ
 );
 
 -- Create login_audit table
 CREATE TABLE IF NOT EXISTS login_audit (
-    id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES users(id),
-    action VARCHAR(50) NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  action VARCHAR(50) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Drop existing patients table if exists
@@ -20,27 +20,38 @@ DROP TABLE IF EXISTS patients;
 
 -- Create patients table
 CREATE TABLE patients (
-    id SERIAL PRIMARY KEY,
-    first_name VARCHAR(100) NOT NULL,
-    last_name VARCHAR(100) NOT NULL,
-    gender VARCHAR(50),
-    blood_type VARCHAR(5),
-    rh_factor VARCHAR(10),
-    duty_status VARCHAR(50),
-    pid VARCHAR(50) UNIQUE,
-    paygrade VARCHAR(5),
-    branch_of_service VARCHAR(50),
-    ethnicity VARCHAR(50),
-    religion VARCHAR(50),
-    dod_id BIGINT UNIQUE,
-    date_of_birth DATE,
-    phone_number VARCHAR(20),
-    is_active BOOLEAN DEFAULT true,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  id SERIAL PRIMARY KEY,
+  first_name VARCHAR(100) NOT NULL,
+  last_name VARCHAR(100) NOT NULL,
+  gender VARCHAR(50),
+  blood_type VARCHAR(5),
+  rh_factor VARCHAR(10),
+  duty_status VARCHAR(50),
+  pid VARCHAR(50) UNIQUE,
+  paygrade VARCHAR(5),
+  branch_of_service VARCHAR(50),
+  ethnicity VARCHAR(50),
+  religion VARCHAR(50),
+  dod_id BIGINT UNIQUE,
+  date_of_birth DATE,
+  phone_number VARCHAR(20),
+  is_active BOOLEAN DEFAULT true,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create environments table
+CREATE TABLE IF NOT EXISTS environments (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL,
+  last_check TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  api_version TEXT,
+  db_status TEXT,
+  uptime_seconds INTEGER DEFAULT 0
 );
 
 -- Insert default admin user if not exists
 INSERT INTO users (email, password_hash, role)
 SELECT 'admin@example.com', '$2a$10$zPzBqiVZwH1jJQX1H6mOY.kF8LyU1K89Y.j.ZjIqGKZYd.JnSbGqK', 'admin'
-WHERE NOT EXISTS (SELECT 1 FROM users WHERE email = 'admin@example.com'); 
+WHERE NOT EXISTS (SELECT 1 FROM users WHERE email = 'admin@example.com');

--- a/db/migrations/005_create_environments.sql
+++ b/db/migrations/005_create_environments.sql
@@ -1,0 +1,10 @@
+-- Create environments table for system health monitoring
+CREATE TABLE IF NOT EXISTS environments (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL,
+  last_check TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  api_version TEXT,
+  db_status TEXT,
+  uptime_seconds INTEGER DEFAULT 0
+);

--- a/db/seed_environments.sql
+++ b/db/seed_environments.sql
@@ -1,0 +1,4 @@
+INSERT INTO environments (name, status, last_check, api_version, db_status, uptime_seconds)
+VALUES
+  ('Production', 'Online', NOW(), 'v1.2.0', 'online', 86400),
+  ('Staging', 'Degraded', NOW(), 'v1.2.0-rc', 'online', 43200);

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ const PORT = process.env.PORT || 3000
 
 // Import routes
 const patientRoutes = require('./routes/patients')
+const environmentRoutes = require('./routes/environments')
 
 // Middleware
 app.use(cors({
@@ -37,6 +38,7 @@ app.use((req, res, next) => {
 
 // Use routes
 app.use('/api/patients', patientRoutes)
+app.use('/api/environments', environmentRoutes)
 
 app.post('/api/login', async (req, res) => {
   const { email, password } = req.body
@@ -218,6 +220,8 @@ if (require.main === module) {
     console.log('- PUT    /api/patients/:id')
     console.log('- DELETE /api/patients/:id')
     console.log('- GET    /api/patients/search/:query')
+    console.log('- GET    /api/environments')
+    console.log('- GET    /api/environments/:id')
     console.log('- GET    /api/v1/health/status')
   })
 }

--- a/server/routes/environments.js
+++ b/server/routes/environments.js
@@ -1,0 +1,35 @@
+const express = require('express')
+const router = express.Router()
+const pool = require('../db')
+
+// Get all environments
+router.get('/', async (req, res) => {
+  try {
+    const result = await pool.query(
+      'SELECT id, name, status, last_check FROM environments ORDER BY name'
+    )
+    res.json(result.rows)
+  } catch (err) {
+    console.error('Error fetching environments:', err)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+})
+
+// Get single environment
+router.get('/:id', async (req, res) => {
+  try {
+    const { id } = req.params
+    const result = await pool.query('SELECT * FROM environments WHERE id = $1', [
+      id
+    ])
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Environment not found' })
+    }
+    res.json(result.rows[0])
+  } catch (err) {
+    console.error('Error fetching environment:', err)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+})
+
+module.exports = router

--- a/src/components/EnvironmentStatusCard.vue
+++ b/src/components/EnvironmentStatusCard.vue
@@ -1,0 +1,68 @@
+<template>
+  <div
+    @click="openModal"
+    class="p-4 bg-white dark:bg-gray-700 rounded shadow cursor-pointer flex justify-between items-center hover:shadow-lg"
+  >
+    <div>
+      <p class="text-lg font-semibold">{{ environment.name }}</p>
+      <p class="text-sm text-gray-500 dark:text-gray-300">{{ formattedDate }}</p>
+    </div>
+    <span :class="['w-3 h-3 rounded-full', statusColor]"></span>
+  </div>
+
+  <div
+    v-if="show"
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+  >
+    <div class="bg-white dark:bg-gray-700 p-4 rounded shadow w-80">
+      <h2 class="text-xl font-semibold mb-2">{{ environment.name }} Details</h2>
+      <p class="mb-1"><strong>Status:</strong> {{ details.status }}</p>
+      <p class="mb-1"><strong>API Version:</strong> {{ details.api_version }}</p>
+      <p class="mb-1"><strong>Database:</strong> {{ details.db_status }}</p>
+      <p class="mb-3"><strong>Uptime:</strong> {{ details.uptime_seconds }}s</p>
+      <button
+        @click="show = false"
+        class="mt-2 px-4 py-2 bg-blue-500 text-white rounded"
+      >
+        Close
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  environment: { type: Object, required: true }
+})
+
+const show = ref(false)
+const details = ref({ ...props.environment })
+
+const formattedDate = computed(() =>
+  new Date(props.environment.last_check).toLocaleString()
+)
+
+const statusColor = computed(() => {
+  const status = props.environment.status
+  if (status === 'Online') return 'bg-green-500'
+  if (status === 'Degraded') return 'bg-yellow-500'
+  return 'bg-red-500'
+})
+
+const openModal = async () => {
+  try {
+    const res = await fetch(`/api/environments/${props.environment.id}`)
+    if (res.ok) {
+      details.value = await res.json()
+    }
+  } catch (err) {
+    console.error('Error loading environment details', err)
+  } finally {
+    show.value = true
+  }
+}
+</script>
+
+<style scoped></style>

--- a/src/components/EnvironmentalDashboard.vue
+++ b/src/components/EnvironmentalDashboard.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="mt-8 space-y-8">
+    <!-- Environment Status Cards -->
+    <section class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <EnvironmentStatusCard
+        v-for="env in environments"
+        :key="env.id"
+        :environment="env"
+      />
+    </section>
     <!-- Metrics -->
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
       <div class="bg-white dark:bg-gray-700 p-4 rounded shadow">
@@ -138,10 +146,13 @@
 </template>
 
 <script>
+import EnvironmentStatusCard from './EnvironmentStatusCard.vue'
 export default {
   name: 'EnvironmentalDashboard',
+  components: { EnvironmentStatusCard },
   data() {
     return {
+      environments: [],
       metrics: {
         locations: 3,
         personnel: 12,
@@ -165,6 +176,21 @@ export default {
         { id: 'S-002', date: '2024-04-05', type: 'Soil', location: 'Forward Site', result: '2 ppm' }
       ]
     }
+  },
+  methods: {
+    async fetchEnvironments() {
+      try {
+        const res = await fetch('/api/environments')
+        if (res.ok) {
+          this.environments = await res.json()
+        }
+      } catch (err) {
+        console.error('Failed to load environments', err)
+      }
+    }
+  },
+  mounted() {
+    this.fetchEnvironments()
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- add environments table and seed
- expose `/api/environments` routes
- show status cards in `EnvironmentalDashboard`
- create `EnvironmentStatusCard` component
- document new feature in README

## Testing
- `npm run lint` *(fails: cannot find eslint-plugin-vue)*

------
https://chatgpt.com/codex/tasks/task_e_685bfc2b6e4883268f30ac5c4a631beb