### PR TITLE
Add loading and error states to Navy dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ If the last login timestamp is not displaying:
 - The dashboard fetches and displays the latest data in cards.
 - Status is color-coded (green for Good/Safe, yellow for Moderate, red for others).
 - Last updated time is shown.
+- A spinner appears while data loads and an error message is shown if the fetch fails.
 - Chart integration is ready (see below).
 
 ### Chart Integration
@@ -277,6 +278,7 @@ If the last login timestamp is not displaying:
 ### Frontend Usage
 - The Navy Environmental Health Tracker dashboard fetches and displays data from these endpoints in real time.
 - Data is color-coded and organized into cards and tables for easy review.
+- A spinner appears while data loads and an error message is shown if the fetch fails.
 
 ### Troubleshooting
 - If the dashboard is empty, ensure you have run both the migration and the seed script above.

--- a/src/components/EnvironmentalDashboard.vue
+++ b/src/components/EnvironmentalDashboard.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="bg-gray-700 rounded-lg shadow-lg p-8 mb-8">
+  <div v-if="loading" class="flex items-center justify-center h-64">
+    <div class="animate-spin rounded-full h-12 w-12 border-4 border-blue-400 border-t-transparent"></div>
+  </div>
+  <div v-else-if="error" class="bg-red-100 text-red-700 p-4 rounded-lg text-center">
+    <p>Failed to load data: {{ error }}</p>
+  </div>
+  <div v-else class="bg-gray-700 rounded-lg shadow-lg p-8 mb-8">
     <h2 class="text-3xl font-bold text-blue-400 mb-2">Environmental Dashboard</h2>
     <p class="text-lg text-gray-200 mb-6">Monitor and analyze environmental data and trends.</p>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- improve EnvironmentalDashboard component with spinner and error message
- document new loading and error states for Environmental and Navy dashboards

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-vue')*
- `npm install` *(fails: dependency conflict for vue-jest)*

------
https://chatgpt.com/codex/tasks/task_e_685c6f3021888326915d48e80dfb3f1d