### PR TITLE
Add loading/error states for Navy dashboard

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -249,6 +249,7 @@
 - Update the Vue dashboard to fetch data from the new backend endpoints using `fetch` and `onMounted`.
 - Replace all mock data with live API data.
 - Use Vue's reactivity to update the UI as data loads.
+- Implement a loading spinner overlay and show a clear error message if any fetch fails.
 
 ### 5. Documentation & Workflow
 - Update the README with migration and seeding instructions, new endpoints, and troubleshooting tips.

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ If the last login timestamp is not displaying:
 - The dashboard fetches and displays the latest data in cards.
 - Status is color-coded (green for Good/Safe, yellow for Moderate, red for others).
 - Last updated time is shown.
-- A spinner appears while data loads and an error message is shown if the fetch fails.
+- A spinner overlays the dashboard while data loads. If the fetch fails, the content is replaced with an error message.
 - Chart integration is ready (see below).
 
 ### Chart Integration
@@ -278,7 +278,7 @@ If the last login timestamp is not displaying:
 ### Frontend Usage
 - The Navy Environmental Health Tracker dashboard fetches and displays data from these endpoints in real time.
 - Data is color-coded and organized into cards and tables for easy review.
-- A spinner appears while data loads and an error message is shown if the fetch fails.
+- A spinner overlays the dashboard while data loads. If the fetch fails, the content is replaced with an error message.
 
 ### Troubleshooting
 - If the dashboard is empty, ensure you have run both the migration and the seed script above.

--- a/src/views/NavyDashboard.vue
+++ b/src/views/NavyDashboard.vue
@@ -1,5 +1,15 @@
 <template>
-  <div class="min-h-screen bg-black text-white py-10 px-4">
+  <div class="min-h-screen bg-black text-white py-10 px-4 relative">
+    <div v-if="isLoading" class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <svg class="animate-spin h-10 w-10 text-blue-500" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+      </svg>
+    </div>
+    <div v-if="error" class="max-w-7xl mx-auto mt-20 p-6 border border-red-500 text-red-400 rounded bg-gray-900 text-center">
+      {{ error }}
+    </div>
+    <div v-else>
     <!-- Title -->
     <div class="max-w-7xl mx-auto mb-8">
       <h1 class="text-4xl font-bold text-blue-300 mb-2">Navy Environmental Health Tracker</h1>
@@ -158,6 +168,7 @@
         </table>
       </div>
     </div>
+    </div>
   </div>
 </template>
 
@@ -176,20 +187,31 @@ const exposureEvents = ref([])
 const bioTests = ref([])
 const medSurveillance = ref([])
 const deploymentLogs = ref([])
+const isLoading = ref(true)
+const error = ref(null)
 
 async function fetchAll() {
-  const [ov, ev, bt, ms, dl] = await Promise.all([
-    fetch('/api/navy/overview').then(r => r.json()),
-    fetch('/api/navy/exposure-events').then(r => r.json()),
-    fetch('/api/navy/bio-tests').then(r => r.json()),
-    fetch('/api/navy/med-surveillance').then(r => r.json()),
-    fetch('/api/navy/deployment-logs').then(r => r.json()),
-  ])
-  overview.value = ov
-  exposureEvents.value = ev
-  bioTests.value = bt
-  medSurveillance.value = ms
-  deploymentLogs.value = dl
+  isLoading.value = true
+  error.value = null
+  try {
+    const [ov, ev, bt, ms, dl] = await Promise.all([
+      fetch('/api/navy/overview').then(r => r.json()),
+      fetch('/api/navy/exposure-events').then(r => r.json()),
+      fetch('/api/navy/bio-tests').then(r => r.json()),
+      fetch('/api/navy/med-surveillance').then(r => r.json()),
+      fetch('/api/navy/deployment-logs').then(r => r.json()),
+    ])
+    overview.value = ov
+    exposureEvents.value = ev
+    bioTests.value = bt
+    medSurveillance.value = ms
+    deploymentLogs.value = dl
+  } catch (e) {
+    console.error(e)
+    error.value = 'Failed to fetch Navy dashboard data.'
+  } finally {
+    isLoading.value = false
+  }
 }
 
 onMounted(fetchAll)


### PR DESCRIPTION
## Summary
- show spinner overlay while Navy dashboard data loads and display error message on failure
- document the new loading and error behavior in README and LESSONS

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-vue')*

------
https://chatgpt.com/codex/tasks/task_e_686c106133c8832684d36e0da9c1fdc7