### PR TITLE
Add patient water test feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ After successful login, users can access two main modules:
      - Dark mode support with proper contrast
      - Medical Records
      - Appointment Scheduling
-     - Environmental Dashboard for exposure tracking
-     - Environment status cards with modal details
+    - Environmental Dashboard for exposure tracking
+    - Record water test results for each patient
+    - Environment status cards with modal details
    - Blue-themed interface
 
 2. **RH Module (Resource & Hospital)**
@@ -215,6 +216,10 @@ If the last login timestamp is not displaying:
    INSERT INTO environmental_data (pm25, pm10, o3, lead, arsenic, status_air, status_water)
    VALUES (15, 22, 0.04, 0.001, 0.0002, 'Good', 'Safe');
    ```
+3. **Create patient water tests table:**
+   ```sh
+   psql -U postgres -d ehr_eng2 -f db/migrations/008_create_patient_water_tests.sql
+   ```
 
 ### Backend API
 - **Route:** `GET /api/environmental/latest`
@@ -227,6 +232,10 @@ If the last login timestamp is not displaying:
   }
   ```
 - Returns 404 if no data is present.
+
+### Patient Water Test API
+- `GET /api/patients/:id/water-tests` — List all tests for a patient
+- `POST /api/patients/:id/water-tests` — Add a new water test
 
 ### Frontend Usage
 - The dashboard fetches and displays the latest data in cards.

--- a/db/migrations/008_create_patient_water_tests.sql
+++ b/db/migrations/008_create_patient_water_tests.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS patient_water_tests (
+  id SERIAL PRIMARY KEY,
+  patient_id INTEGER REFERENCES patients(id) ON DELETE CASCADE,
+  lead NUMERIC,
+  arsenic NUMERIC,
+  status VARCHAR(20),
+  recorded_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/server/index.js
+++ b/server/index.js
@@ -286,6 +286,8 @@ if (require.main === module) {
     console.log('- POST   /api/patients')
     console.log('- PUT    /api/patients/:id')
     console.log('- DELETE /api/patients/:id')
+    console.log('- GET    /api/patients/:id/water-tests')
+    console.log('- POST   /api/patients/:id/water-tests')
     console.log('- GET    /api/patients/search/:query')
     console.log('- GET    /api/users/:id')
     console.log('- GET    /api/environments')

--- a/server/models/waterTestModel.js
+++ b/server/models/waterTestModel.js
@@ -1,0 +1,20 @@
+const pool = require('../db')
+
+async function createWaterTest(patientId, { lead, arsenic, status }) {
+  const result = await pool.query(
+    `INSERT INTO patient_water_tests (patient_id, lead, arsenic, status)
+     VALUES ($1, $2, $3, $4) RETURNING *`,
+    [patientId, lead, arsenic, status]
+  )
+  return result.rows[0]
+}
+
+async function getWaterTests(patientId) {
+  const result = await pool.query(
+    'SELECT * FROM patient_water_tests WHERE patient_id = $1 ORDER BY recorded_at DESC',
+    [patientId]
+  )
+  return result.rows
+}
+
+module.exports = { createWaterTest, getWaterTests }

--- a/server/routes/patients.js
+++ b/server/routes/patients.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const pool = require('../db');
 const { updatePatient } = require('../models/patientModel');
+const { createWaterTest, getWaterTests } = require('../models/waterTestModel');
 
 // Get all patients
 router.get('/', async (req, res) => {
@@ -127,6 +128,28 @@ router.delete('/:id', async (req, res) => {
     res.json({ message: 'Patient deactivated successfully' });
   } catch (err) {
     console.error('Error deactivating patient:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Get water tests for a patient
+router.get('/:id/water-tests', async (req, res) => {
+  try {
+    const tests = await getWaterTests(req.params.id);
+    res.json(tests);
+  } catch (err) {
+    console.error('Error fetching water tests:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Add water test for a patient
+router.post('/:id/water-tests', async (req, res) => {
+  try {
+    const test = await createWaterTest(req.params.id, req.body);
+    res.status(201).json(test);
+  } catch (err) {
+    console.error('Error creating water test:', err);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/src/components/WaterTestForm.vue
+++ b/src/components/WaterTestForm.vue
@@ -1,0 +1,54 @@
+<template>
+  <form @submit.prevent="submit" class="grid grid-cols-1 gap-4 mt-4">
+    <div>
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Lead (ppm)</label>
+      <input type="number" step="0.001" v-model.number="lead" class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100" />
+    </div>
+    <div>
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Arsenic (ppm)</label>
+      <input type="number" step="0.001" v-model.number="arsenic" class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100" />
+    </div>
+    <div>
+      <label class="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-1">Status</label>
+      <select v-model="status" class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 dark:border-gray-700">
+        <option value="Safe">Safe</option>
+        <option value="Moderate">Moderate</option>
+        <option value="Unsafe">Unsafe</option>
+      </select>
+    </div>
+    <div class="flex justify-end">
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Add Test</button>
+    </div>
+  </form>
+</template>
+
+<script>
+export default {
+  name: 'WaterTestForm',
+  props: {
+    patientId: { type: Number, required: true }
+  },
+  data() {
+    return { lead: null, arsenic: null, status: 'Safe' }
+  },
+  methods: {
+    async submit() {
+      const res = await fetch(`/api/patients/${this.patientId}/water-tests`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lead: this.lead, arsenic: this.arsenic, status: this.status })
+      })
+      if (res.ok) {
+        this.lead = null
+        this.arsenic = null
+        this.status = 'Safe'
+        this.$emit('saved')
+      } else {
+        console.error('Failed to save water test', await res.text())
+      }
+    }
+  }
+}
+</script>
+
+<style scoped></style>

--- a/src/views/PatientView.vue
+++ b/src/views/PatientView.vue
@@ -22,16 +22,29 @@
       <p class="mb-2"><span class="font-bold">Date of Birth:</span> {{ formatDate(patient.date_of_birth) }}</p>
       <p class="mb-2"><span class="font-bold">Phone:</span> {{ displayPhone(patient.phone_number) }}</p>
     </div>
+    <div v-if="patient" class="mt-6">
+      <h3 class="text-xl font-semibold mb-2">Water Tests</h3>
+      <ul v-if="tests.length" class="mb-4 list-disc ml-6">
+        <li v-for="t in tests" :key="t.id">
+          {{ formatDate(t.recorded_at) }} - Lead: {{ t.lead }} Arsenic: {{ t.arsenic }} ({{ t.status }})
+        </li>
+      </ul>
+      <p v-else class="mb-4">No water tests recorded.</p>
+      <WaterTestForm :patient-id="patient.id" @saved="fetchWaterTests" />
+    </div>
   </div>
 </template>
 
 <script>
 import { formatPhoneNumber } from '../utils/formatters'
+import WaterTestForm from '../components/WaterTestForm.vue'
 export default {
   name: 'PatientView',
+  components: { WaterTestForm },
   data() {
     return {
-      patient: null
+      patient: null,
+      tests: []
     }
   },
   async mounted() {
@@ -40,6 +53,7 @@ export default {
       const res = await fetch(`/api/patients/${id}`)
       if (res.ok) {
         this.patient = await res.json()
+        await this.fetchWaterTests()
       } else {
         console.error('Failed to fetch patient', await res.text())
       }
@@ -53,6 +67,12 @@ export default {
     },
     displayPhone(number) {
       return formatPhoneNumber(number)
+    },
+    async fetchWaterTests() {
+      const res = await fetch(`/api/patients/${this.patient.id}/water-tests`)
+      if (res.ok) {
+        this.tests = await res.json()
+      }
     }
   }
 }

--- a/tests/frontend/WaterTestForm.test.js
+++ b/tests/frontend/WaterTestForm.test.js
@@ -1,0 +1,15 @@
+const { mount } = require('@vue/test-utils')
+const Vue = require('vue')
+global.Vue = Vue
+const WaterTestForm = require('../../src/components/WaterTestForm.vue').default
+
+global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+
+describe('WaterTestForm', () => {
+  it('posts data and emits event', async () => {
+    const wrapper = mount(WaterTestForm, { propsData: { patientId: 1 } })
+    await wrapper.find('form').trigger('submit.prevent')
+    expect(global.fetch).toHaveBeenCalled()
+    expect(wrapper.emitted().saved).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- allow recording water tests for each patient
- view tests on patient detail page
- expose new REST routes for patient water tests
- document setup and usage
- add unit test for WaterTestForm

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68750f5649dc83269404cb6dc9a35d2c