### PR TITLE
Display agent while task runs

### DIFF
--- a/src/components/AgentDashboard.vue
+++ b/src/components/AgentDashboard.vue
@@ -25,7 +25,7 @@
               <td class="py-2">{{ task.agent }}</td>
               <td class="py-2">{{ task.task }}</td>
               <td class="py-2">
-                <span :class="statusColor(task.status)">{{ task.status }}</span>
+                <span :class="statusColor(task.status)">{{ statusText(task) }}</span>
               </td>
               <td class="py-2">{{ task.output }}</td>
             </tr>
@@ -66,6 +66,12 @@ export default {
         console.error('Error starting workflow:', error);
         this.workflowRunning = false;
       }
+    },
+    statusText(task) {
+      if (task.status === 'COMPLETE' || task.status === 'FAILED') {
+        return task.status;
+      }
+      return `${task.status} - ${task.agent} working`;
     },
     statusColor(status) {
       const colors = {


### PR DESCRIPTION
## Summary
- show which agent is processing each task in dashboard status column

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892538f30e4832693dab26045c25ffe