### PR TITLE
Add medical personnel summary table

### DIFF
--- a/db/migrations/018_create_medical_personnel_summary.sql
+++ b/db/migrations/018_create_medical_personnel_summary.sql
@@ -1,0 +1,19 @@
+-- Migration: Create medical personnel summary table
+
+CREATE TABLE IF NOT EXISTS medical_personnel_summary (
+  occ_code INTEGER PRIMARY KEY,
+  category TEXT NOT NULL,
+  example_personnel_type TEXT NOT NULL
+);
+
+INSERT INTO medical_personnel_summary (occ_code, category, example_personnel_type) VALUES
+  (10, 'Medical Service, General', 'General HM, generic medical billets'),
+  (11, 'Medical Service, Specialists', 'HM-L05A Radiation Health Technician (enlisted)'),
+  (20, 'Dental Service', 'Dental Corps personnel'),
+  (21, 'Preventive Medicine / Environmental Health', 'MSC 230X Radiation Health Officer (officer)'),
+  (30, 'Veterinary Service', 'Veterinary officer billets'),
+  (40, 'Medical Administration', 'Medical admin staff'),
+  (50, 'Allied Sciences', 'Laboratory, radiography, biomedical science')
+ON CONFLICT (occ_code) DO UPDATE SET
+  category = EXCLUDED.category,
+  example_personnel_type = EXCLUDED.example_personnel_type;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -112,3 +112,22 @@ CREATE TABLE pop3 (
     id SERIAL PRIMARY KEY,
     dodid INTEGER NOT NULL
 );
+
+-- Medical personnel summary table
+CREATE TABLE IF NOT EXISTS medical_personnel_summary (
+  occ_code INTEGER PRIMARY KEY,
+  category TEXT NOT NULL,
+  example_personnel_type TEXT NOT NULL
+);
+
+INSERT INTO medical_personnel_summary (occ_code, category, example_personnel_type) VALUES
+  (10, 'Medical Service, General', 'General HM, generic medical billets'),
+  (11, 'Medical Service, Specialists', 'HM-L05A Radiation Health Technician (enlisted)'),
+  (20, 'Dental Service', 'Dental Corps personnel'),
+  (21, 'Preventive Medicine / Environmental Health', 'MSC 230X Radiation Health Officer (officer)'),
+  (30, 'Veterinary Service', 'Veterinary officer billets'),
+  (40, 'Medical Administration', 'Medical admin staff'),
+  (50, 'Allied Sciences', 'Laboratory, radiography, biomedical science')
+ON CONFLICT (occ_code) DO UPDATE SET
+  category = EXCLUDED.category,
+  example_personnel_type = EXCLUDED.example_personnel_type;


### PR DESCRIPTION
## Summary
- add a migration that creates the `medical_personnel_summary` table and seeds the provided OCC codes
- update `db/schema.sql` with the same table definition and idempotent seed data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0215024dc832682e4f00b1c89920e